### PR TITLE
fix(tools/portforward): return error when connection dies

### DIFF
--- a/tools/portforward/portforward.go
+++ b/tools/portforward/portforward.go
@@ -230,7 +230,7 @@ func (pf *PortForwarder) forward() error {
 	select {
 	case <-pf.stopChan:
 	case <-pf.streamConn.CloseChan():
-		runtime.HandleError(errors.New("lost connection to pod"))
+		return fmt.Errorf("lost connection to pod")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does**: Returns an error when the connection dies to the parent pod, instead of leaving it open as a zombie. This allows for "refreshing" a connection.